### PR TITLE
fixed font loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
      ╚═════╝ ╚═╝       ╚═════╝  ╚═╝  ╚═══╝    ╚═╝    ╚══════╝
 ```
 
-![cfont styles](./img/example1.png)
+![cfont styles](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/example1.png)
 
-<p align="center"><img src="./img/example2.png" alt="api example"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/example2.png" alt="api example"></p>
 <p align="center">
 	<a href="https://crates.io/crates/cfonts"><img src="https://img.shields.io/crates/v/cfonts.svg" alt="crates badge"></a>
 	<a href="https://crates.io/crates/cfonts"><img src="https://docs.rs/cfonts/badge.svg" alt="crates docs tests"></a>
@@ -24,11 +24,11 @@
 
 ### Rust
 
-Read more in the [Rust folder](./rust).
+Read more in the [Rust folder](https://github.com/dominikwilkowski/cfonts/tree/released/rust).
 
 ### Nodejs
 
-Read more in the [Nodejs folder](./nodejs).
+Read more in the [Nodejs folder](https://github.com/dominikwilkowski/cfonts/tree/released/nodejs).
 
 
 ## Install
@@ -158,7 +158,7 @@ This shows a list of all available options.
 $ cfonts --help
 ```
 
-![Help command](./img/help.png)
+![Help command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/help.png)
 
 
 #### -V, --version
@@ -171,7 +171,7 @@ This shows the installed version.
 $ cfonts --version
 ```
 
-![Version command](./img/version.png)
+![Version command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/version.png)
 
 
 #### text
@@ -185,7 +185,7 @@ The `|` character will be replaced with a line break.
 $ cfonts "Hello world"
 ```
 
-![Text command](./img/text.png)
+![Text command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/text.png)
 
 
 #### -f, --font
@@ -198,34 +198,34 @@ This is the font face you want to use. So far this plugin ships with with follow
 $ cfonts "text" --font "chrome"
 ```
 
-![Font command](./img/font.png)
+![Font command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/font.png)
 
 - `block`       [colors: 2] _(default)_
-	![block font style](./img/block.png)
+	![block font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/block.png)
 - `slick`       [colors: 2]
-	![slick font style](./img/slick.png)
+	![slick font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/slick.png)
 - `tiny`        [colors: 1]
-	![tiny font style](./img/tiny.png)
+	![tiny font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/tiny.png)
 - `grid`        [colors: 2]
-	![grid font style](./img/grid.png)
+	![grid font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/grid.png)
 - `pallet`      [colors: 2]
-	![pallet font style](./img/pallet.png)
+	![pallet font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/pallet.png)
 - `shade`       [colors: 2]
-	![shade font style](./img/shade.png)
+	![shade font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/shade.png)
 - `chrome`      [colors: 3]
-	![chrome font style](./img/chrome.png)
+	![chrome font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/chrome.png)
 - `simple`      [colors: 1]
-	![simple font style](./img/simple.png)
+	![simple font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/simple.png)
 - `simpleBlock` [colors: 1]
-	![simple-block font style](./img/simple-block.png)
+	![simple-block font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/simple-block.png)
 - `3d`          [colors: 2]
-	![3d font style](./img/3d.png)
+	![3d font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/3d.png)
 - `simple3d`    [colors: 1]
-	![simple-3d font style](./img/simple-3d.png)
+	![simple-3d font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/simple-3d.png)
 - `huge`        [colors: 2]
-	![huge font style](./img/huge.png)
+	![huge font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/huge.png)
 - `console`     [colors: 1]
-	![console font style](./img/console.png)
+	![console font style](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/console.png)
 
 
 #### -a, --align
@@ -244,7 +244,7 @@ You can align your text in the terminal with this option. Use the keywords below
 $ cfonts "text" --align "center"
 ```
 
-![Align command](./img/align.png)
+![Align command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/align.png)
 
 
 #### -c, --colors
@@ -283,7 +283,7 @@ The `system` color falls back to the system color of your terminal.
 $ cfonts "text" --colors white,"#f80"
 ```
 
-![Colors command](./img/colors.png)
+![Colors command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/colors.png)
 
 
 #### -g, --gradient
@@ -315,7 +315,7 @@ If you use a hex color make sure you include the `#` prefix. _(In the terminal w
 $ cfonts "text" --gradient red,"#f80"
 ```
 
-![Gradient command](./img/gradient.png)
+![Gradient command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/gradient.png)
 
 
 #### -i, --independent-gradient
@@ -329,7 +329,7 @@ Only works in combination with the [gradient](#-g---gradient) option.
 $ cfonts "text|next line" --gradient red,"#f80" --independent-gradient
 ```
 
-![Independent gradient command](./img/independent-gradient.png)
+![Independent gradient command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/independent-gradient.png)
 
 
 #### -t, --transition-gradient
@@ -345,7 +345,7 @@ Only works in combination with the [gradient](#-g---gradient) option.
 $ cfonts "text" --gradient red,"#f80",green,blue --transition-gradient
 ```
 
-![Independent gradient command](./img/transition-gradient.png)
+![Independent gradient command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/transition-gradient.png)
 
 
 #### -b, --background
@@ -379,7 +379,7 @@ Provide the background color from the below supported list, eg: 'white'
 $ cfonts "text" --background "Green"
 ```
 
-![Background command](./img/background.png)
+![Background command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/background.png)
 
 
 #### -l, --letter-spacing
@@ -392,7 +392,7 @@ Set this option to widen the space between characters.
 $ cfonts "text" --letter-spacing 2
 ```
 
-![Letter spacing command](./img/letter-spacing.png)
+![Letter spacing command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/letter-spacing.png)
 
 
 #### -z, --line-height
@@ -405,7 +405,7 @@ Set this option to widen the space between lines.
 $ cfonts "text" --line-height 2
 ```
 
-![Line height command](./img/line-height.png)
+![Line height command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/line-height.png)
 
 
 #### -s, --spaceless
@@ -418,7 +418,7 @@ Set this option to false if you don't want the plugin to insert two empty lines 
 $ cfonts "text" --spaceless
 ```
 
-![Spaceless command](./img/spaceless.png)
+![Spaceless command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/spaceless.png)
 
 
 #### -m, --max-length
@@ -433,7 +433,7 @@ This option sets the maximum characters that will be printed on one line.
 $ cfonts "text" --max-length 15
 ```
 
-![Max length command](./img/max-length.png)
+![Max length command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/max-length.png)
 
 
 #### -e, --env
@@ -447,7 +447,7 @@ Note that `max-length` will be set to very large.
 $ cfonts "text" --env browser
 ```
 
-![Max length command](./img/env.png)
+![Max length command](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/env.png)
 
 
 ## Consistency
@@ -467,7 +467,7 @@ NO_COLOR="" cfonts "hello world" -c "#0088ff"
 
 💡  `FORCE_COLOR` overrides `NO_COLOR` if both are set.
 
-![Color consistency via env vars](./img/color-consistency.png)
+![Color consistency via env vars](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/color-consistency.png)
 
 
 ## License

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -7,9 +7,9 @@
      ╚═════╝ ╚═╝       ╚═════╝  ╚═╝  ╚═══╝    ╚═╝    ╚══════╝    ╝╚╝ ╚═╝ ═╩╝ ╚═╝ ╚╝ ╚═╝
 ```
 
-![cfont styles](../img/example1.png)
+![cfont styles](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/example1.png)
 
-<p align="center"><img src="../img/example2.png" alt="api example"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/example2.png" alt="api example"></p>
 <p align="center">
 	<a href="https://github.com/dominikwilkowski/cfonts/actions/workflows/testing.yml"><img src="https://github.com/dominikwilkowski/cfonts/actions/workflows/testing.yml/badge.svg" alt="build status"></a>
 	<a href="https://www.npmjs.com/package/cfonts"><img alt="npm" src="https://img.shields.io/npm/v/cfonts"></a>
@@ -79,7 +79,7 @@ prettyFont.options // returns the options used
 
 ## CLI Usage
 
-Read more in the [root repo](../).
+Read more in the [root repo](https://github.com/dominikwilkowski/cfonts).
 
 
 ## Tests

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfonts"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Dominik Wilkowski <Hi@Dominik-Wilkowski.com>"]
 license = "GPL-3.0-or-later"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/dominikwilkowski/cfonts"
 documentation = "https://docs.rs/cfonts/"
 keywords = ["fonts", "color", "console", "ascii", "ANSI"]
 categories = ["command-line-interface", "command-line-utilities", "graphics"]
-include = ["/fonts", "/src", "!.DS_Store"]
 
 [dependencies]
 exitcode = "1.1.2"

--- a/rust/README.md
+++ b/rust/README.md
@@ -134,6 +134,7 @@ We also have an [end-to-end test script](./tests/end-to-end/index.js) setup that
 
 ## Release History
 
+* 1.0.1  -  Fixed font loading
 * 1.0.0  -  Public release of rust API
 * 0.1.0  -  alpha test
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -7,9 +7,9 @@
      ╚═════╝ ╚═╝       ╚═════╝  ╚═╝  ╚═══╝    ╚═╝    ╚══════╝    ╩╚═ ╚═╝ ╚═╝  ╩
 ```
 
-![cfont styles](../img/example1.png)
+![cfont styles](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/example1.png)
 
-<p align="center"><img src="../img/example2.png" alt="api example"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/example2.png" alt="api example"></p>
 <p align="center">
 	<a href="https://crates.io/crates/cfonts"><img src="https://img.shields.io/crates/v/cfonts.svg" alt="crates badge"></a>
 	<a href="https://crates.io/crates/cfonts"><img src="https://docs.rs/cfonts/badge.svg" alt="crates docs tests"></a>
@@ -112,7 +112,7 @@ fn main() {
 
 ## CLI Usage
 
-Read more in the [root repo](../).
+Read more in the [root repo](https://github.com/dominikwilkowski/cfonts).
 
 
 ## Tests

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -9,7 +9,7 @@ use crate::helpers::first_letter_to_lowercase;
 /// The `Fonts` enum includes all font options you have for the cfonts output
 ///
 /// Find out more about what each font looks like in the [`Readme`](https://github.com/dominikwilkowski/cfonts/blob/released/README.md)
-#[derive(EnumIter, Debug, Clone, PartialEq)]
+#[derive(EnumIter, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Fonts {
 	/// ![The "console" cfonts font](https://raw.githubusercontent.com/dominikwilkowski/cfonts/released/img/console.png)
 	FontConsole,

--- a/rust/src/font.rs
+++ b/rust/src/font.rs
@@ -3,8 +3,6 @@ extern crate serde_json;
 use serde::Deserialize;
 
 use std::collections::HashMap;
-use std::fs::read_to_string;
-use std::path::Path;
 
 use crate::color::color;
 use crate::config::{Colors, Fonts, Options};
@@ -33,18 +31,79 @@ pub struct Font {
 	pub chars: HashMap<String, Vec<String>>,
 }
 
+/// Function to embed the data of our font files into our binary
+///
+/// ```rust
+/// extern crate cfonts;
+///
+/// use cfonts::{ Options, Fonts };
+/// use cfonts::font::{load_all_fonts, get};
+///
+/// let mut options = Options::default();
+/// options.font = Fonts::FontChrome;
+///
+/// let fonts = load_all_fonts(); // our HashMap of all font files content
+/// let this_font = get(&fonts, &options);
+/// assert_eq!(this_font.name, String::from("chrome"));
+/// ```
+pub fn load_all_fonts() -> HashMap<Fonts, &'static str> {
+	let mut fonts = HashMap::new();
+
+	let font_content = include_str!("../fonts/console.json");
+	fonts.insert(Fonts::FontConsole, font_content);
+
+	let font_content = include_str!("../fonts/block.json");
+	fonts.insert(Fonts::FontBlock, font_content);
+
+	let font_content = include_str!("../fonts/simpleBlock.json");
+	fonts.insert(Fonts::FontSimpleBlock, font_content);
+
+	let font_content = include_str!("../fonts/simple.json");
+	fonts.insert(Fonts::FontSimple, font_content);
+
+	let font_content = include_str!("../fonts/3d.json");
+	fonts.insert(Fonts::Font3d, font_content);
+
+	let font_content = include_str!("../fonts/simple3d.json");
+	fonts.insert(Fonts::FontSimple3d, font_content);
+
+	let font_content = include_str!("../fonts/chrome.json");
+	fonts.insert(Fonts::FontChrome, font_content);
+
+	let font_content = include_str!("../fonts/huge.json");
+	fonts.insert(Fonts::FontHuge, font_content);
+
+	let font_content = include_str!("../fonts/shade.json");
+	fonts.insert(Fonts::FontShade, font_content);
+
+	let font_content = include_str!("../fonts/slick.json");
+	fonts.insert(Fonts::FontSlick, font_content);
+
+	let font_content = include_str!("../fonts/grid.json");
+	fonts.insert(Fonts::FontGrid, font_content);
+
+	let font_content = include_str!("../fonts/pallet.json");
+	fonts.insert(Fonts::FontPallet, font_content);
+
+	let font_content = include_str!("../fonts/tiny.json");
+	fonts.insert(Fonts::FontTiny, font_content);
+
+	fonts
+}
+
 /// Function to get the data of the font chosen
 ///
 /// ```rust
 /// extern crate cfonts;
 ///
 /// use cfonts::{ Options, Fonts };
-/// use cfonts::font::get;
+/// use cfonts::font::{load_all_fonts, get};
 ///
 /// let mut options = Options::default();
 /// options.font = Fonts::FontChrome;
 ///
-/// let this_font = get(&options);
+/// let fonts = load_all_fonts();
+/// let this_font = get(&fonts, &options);
 /// assert_eq!(this_font.name, String::from("chrome"));
 /// ```
 ///
@@ -54,40 +113,24 @@ pub struct Font {
 /// extern crate cfonts;
 ///
 /// use cfonts::{ Options, Fonts };
-/// use cfonts::font::get;
+/// use cfonts::font::{load_all_fonts, get};
 ///
 /// let mut options = Options::default();
 /// options.font = Fonts::FontConsole;
 ///
-/// let this_font = get(&options);
+/// let fonts = load_all_fonts();
+/// let this_font = get(&fonts, &options);
 /// assert_eq!(this_font.chars.get("D").unwrap(), &vec![String::from("d")]);
 /// ```
-pub fn get(options: &Options) -> Font {
+pub fn get(fonts: &HashMap<Fonts, &'static str>, options: &Options) -> Font {
 	d("font::get()", 5, Dt::Head, options, &mut std::io::stdout());
 	d(&format!("font::get()\noptions.font{:?}", options.font), 5, Dt::Log, options, &mut std::io::stdout());
-	let filename = match options.font {
-		Fonts::FontBlock => "./fonts/block.json",
-		Fonts::FontSimpleBlock => "./fonts/simpleBlock.json",
-		Fonts::FontSimple => "./fonts/simple.json",
-		Fonts::Font3d => "./fonts/3d.json",
-		Fonts::FontSimple3d => "./fonts/simple3d.json",
-		Fonts::FontChrome => "./fonts/chrome.json",
-		Fonts::FontHuge => "./fonts/huge.json",
-		Fonts::FontShade => "./fonts/shade.json",
-		Fonts::FontSlick => "./fonts/slick.json",
-		Fonts::FontGrid => "./fonts/grid.json",
-		Fonts::FontPallet => "./fonts/pallet.json",
-		Fonts::FontTiny => "./fonts/tiny.json",
-		Fonts::FontConsole => "./fonts/console.json",
-	};
-	d(&format!("font::get() read font file at \"{}\"", filename), 5, Dt::Log, options, &mut std::io::stdout());
+	let data = fonts.get(&options.font).unwrap();
 
-	let data = read_to_string(Path::new(filename).as_os_str())
-		.unwrap_or(format!("Unable to read file \"{}\"", color(filename, Colors::Red)));
-	serde_json::from_str(&data).unwrap_or_else(|error| {
+	serde_json::from_str(data).unwrap_or_else(|error| {
 		panic!(
 			"JSON parsing error encountered for: \"{}\"\nError: {}",
-			color(filename, Colors::Red),
+			color(&format!("{:?}", options.font), Colors::Red),
 			color(&format!("{}", error), Colors::Yellow)
 		)
 	})

--- a/rust/src/render.rs
+++ b/rust/src/render.rs
@@ -77,7 +77,8 @@ pub fn render(options: Options) -> RenderedString {
 	};
 	d(&format!("render()\nterminal_width:{:?}", terminal_width), 1, Dt::Log, &options, &mut std::io::stdout());
 
-	let mut font = font::get(&options);
+	let fonts = font::load_all_fonts();
+	let mut font = font::get(&fonts, &options);
 	let mut line_length = 0;
 	let mut letter_count = 0;
 	let mut lines = 0;


### PR DESCRIPTION
fonts in rust were not loading properly so I moved to the [`include_str`](https://doc.rust-lang.org/std/macro.include_str.html) macro to embed the content of the font jsons into the binary.