### PR TITLE
Updated documentation

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -91,16 +91,16 @@ This package is tested on the below platform and node combinations as part of ou
 | Linux    | v12  |
 | Linux    | v14  |
 | Linux    | v16  |
-| OSX      | v10  |
-| OSX      | v12  |
-| OSX      | v16  |
-| Windows  | v10  |
+| MacOS    | v12  |
+| MacOS    | v14  |
+| MacOS    | v16  |
 | Windows  | v12  |
+| Windows  | v14  |
 | Windows  | v16  |
 
 ### Unit tests
 
-The package comes with a bunch of [unit tests](https://github.com/dominikwilkowski/cfonts/tree/released/test/unit) that aim to cover 100% of the code base.
+The package comes with a bunch of [unit tests](./test/unit) that aim to cover 100% of the code base.
 For more details about the code coverage check out [coveralls](https://coveralls.io/github/dominikwilkowski/cfonts?branch=released).
 
 ```sh
@@ -110,8 +110,7 @@ npm run test:unit
 ### Type tests
 
 Since the code base uses [JSDocs](https://jsdoc.app/) we use [typescript](https://www.typescriptlang.org/) to test the inferred types from those comments.
-Typescript [supports JSDocs](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#supported-jsdoc) and we use it in our
-[test](https://github.com/dominikwilkowski/cfonts/blob/released/nodejs/package.json#L37).
+Typescript [supports JSDocs](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#supported-jsdoc) and we use it in our [test](./package.json#L37).
 
 ```sh
 npm run test:types
@@ -119,7 +118,7 @@ npm run test:types
 
 ### Font file test
 
-There is also a [test suite](https://github.com/dominikwilkowski/cfonts/blob/released/nodejs/test/fonttest.js) for font files.
+There is also a [test suite](./test/fonttest.js) for font files.
 
 ```sh
 npm run test:fonts

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -100,7 +100,7 @@ This package is tested on the below platform and node combinations as part of ou
 
 ### Unit tests
 
-The package comes with a bunch of [unit tests](./test/unit) that aim to cover 100% of the code base.
+The package comes with a bunch of [unit tests](https://github.com/dominikwilkowski/cfonts/blob/released/nodejs/test/unit) that aim to cover 100% of the code base.
 For more details about the code coverage check out [coveralls](https://coveralls.io/github/dominikwilkowski/cfonts?branch=released).
 
 ```sh
@@ -110,7 +110,7 @@ npm run test:unit
 ### Type tests
 
 Since the code base uses [JSDocs](https://jsdoc.app/) we use [typescript](https://www.typescriptlang.org/) to test the inferred types from those comments.
-Typescript [supports JSDocs](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#supported-jsdoc) and we use it in our [test](./package.json#L37).
+Typescript [supports JSDocs](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#supported-jsdoc) and we use it in our [test](https://github.com/dominikwilkowski/cfonts/blob/released/nodejs/package.json#L37).
 
 ```sh
 npm run test:types
@@ -118,7 +118,7 @@ npm run test:types
 
 ### Font file test
 
-There is also a [test suite](./test/fonttest.js) for font files.
+There is also a [test suite](https://github.com/dominikwilkowski/cfonts/blob/released/nodejs/test/fonttest.js) for font files.
 
 ```sh
 npm run test:fonts

--- a/rust/README.md
+++ b/rust/README.md
@@ -135,20 +135,19 @@ Read more in the [root repo](https://github.com/dominikwilkowski/cfonts).
 
 ## Tests
 
-All tests are run via for the below platforms with our [CI](https://github.com/dominikwilkowski/cfonts/tree/released/.github/workflows/testing.yml).
+All tests are run on the below platforms with our [CI](https://github.com/dominikwilkowski/cfonts/tree/released/.github/workflows/testing.yml).
 
 | Platform |
 |----------|
 | Linux    |
-| OSX      |
+| MacOS    |
 | Windows  |
 
 ### Unit tests
 
-There are some unit tests and some integration tests within the `./tests` folder.
+There are some [unit tests and integration tests](./tests) within the `./tests` folder.
 
-We also have an [end-to-end test script](./tests/end-to-end/index.js) setup that runs on the binaries (on all platforms) and compares its output against fixtures and the output of the node implementation.
-
+We also have an [end-to-end test script](./tests/end-to-end_test.rs) setup that runs on the binaries (on all platforms) and compares its output against fixtures and the output of the node implementation.
 
 ## Release History
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -145,9 +145,9 @@ All tests are run on the below platforms with our [CI](https://github.com/domini
 
 ### Unit tests
 
-There are some [unit tests and integration tests](./tests) within the `./tests` folder.
+There are some [unit tests and integration tests](https://github.com/dominikwilkowski/cfonts/blob/released/rust/tests) within the `tests` folder.
 
-We also have an [end-to-end test script](./tests/end-to-end_test.rs) setup that runs on the binaries (on all platforms) and compares its output against fixtures and the output of the node implementation.
+We also have an [end-to-end test script](https://github.com/dominikwilkowski/cfonts/blob/released/rust/tests/end-to-end_test.rs) setup that runs on the binaries (on all platforms) and compares its output against fixtures and the output of the node implementation.
 
 ## Release History
 


### PR DESCRIPTION
While reviewing documentation found some inconsistencies and fixed links. In the Rust/Nodejs documentation I used relative links instead of absolute links, hope this is okay for you.