### PR TITLE
replace pacman with yay

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ brew install cfonts
 #### [Arch User Repository](https://aur.archlinux.org/packages/cfonts)
 
 ```sh
-sudo pacman -S cfonts
+yay -S cfonts
 ```
 
 #### [MacPorts](https://ports.macports.org/port/cfonts/)


### PR DESCRIPTION
In arch pacman is only used to install packages from official repositories, in order to install packages from the aur one might use an aur helper such as yay.