### PR TITLE
Add TypeScript declarations to build process

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -32,7 +32,7 @@
 		"test:lint": "eslint src/",
 		"test:format": "prettier --list-different \"**/*.{js,json}\"",
 		"format": "prettier --write \"**/*.{js,json}\"",
-		"build": "yarn build:lib && yarn build:bin && yarn build:fonts",
+		"build": "yarn build:lib && yarn build:bin && yarn build:fonts && yarn test:types",
 		"build:bin": "npx mkdirp bin && mv lib/bin.js bin/index.js",
 		"build:lib": "npx mkdirp lib && babel src --out-dir lib",
 		"build:fonts": "npx mkdirp fonts && npx cpy-cli \"../fonts/*\" \"./fonts/\"",
@@ -115,11 +115,12 @@
 		"pretty"
 	],
 	"files": [
-		"lib/*.js",
+		"lib/*",
 		"bin/*",
 		"fonts/*"
 	],
 	"main": "lib/index.js",
+	"types": "lib/index.d.ts",
 	"bin": {
 		"cfonts": "./bin/index.js"
 	},


### PR DESCRIPTION
This PR effectively adds the existing TS declarations to the package. The process was simple:

1. Chain the existing types compilation step to the `build` script
2. Include the generated types in the allowed `files` property of `package.json`
3. Set the `types` entrypoint in `package.json`

From a maintenance/burden perspective, I think this doesn't change your existing flow because types are already present and I assume you maintain them already for testing purposes.

In issues #60, #64 it was mentioned that PRs are welcomed to add this feature, so here I am. However, let me know if there are any questions or doubts about this addition.
