### PR TITLE
Bump supports-color to version 2 in rust

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.8.5"
 terminal_size = "0.2.3"
-supports-color = "1"
+supports-color = "2"
 
 [dev-dependencies]
 temp-env = "0.3.0"


### PR DESCRIPTION
Bump supports-color to version 2 in Rust