### PR TITLE
Add NixOS install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ sudo port install cfonts
 cargo install cfonts
 ```
 
-#### NixOS
+#### [NixOS](https://search.nixos.org/packages?show=cfonts)
 
 ``` sh
 nix-env -iA nixos.cfonts

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ yay -S cfonts
 sudo dnf install cfonts
 ```
 
+#### [NixOS](https://search.nixos.org/packages?show=cfonts)
+
+``` sh
+nix-env -iA nixos.cfonts
+```
+
 #### [MacPorts](https://ports.macports.org/port/cfonts/)
 
 ```sh
@@ -96,13 +102,6 @@ sudo port install cfonts
 ```sh
 cargo install cfonts
 ```
-
-#### [NixOS](https://search.nixos.org/packages?show=cfonts)
-
-``` sh
-nix-env -iA nixos.cfonts
-```
-
 
 ### NodeJs
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,16 @@ sudo port install cfonts
 cargo install cfonts
 ```
 
-#### [npm](https://www.npmjs.com/package/cfonts)
+#### NixOS
+
+``` sh
+nix-env -iA nixos.cfonts
+```
+
 
 ### NodeJs
+
+#### [npm](https://www.npmjs.com/package/cfonts)
 
 ```sh
 npm i cfonts -g


### PR DESCRIPTION
Hi, I package `cfonts` for `nix`.
This PR add one of the options of installing it on an NixOS system.
Creating a shell with `cfonts` on `$PATH` can be done like this
```sh
nix-shell -p cfonts
```
Simply running it could be done with:
```sh
nix run nixpkgs#cfonts
```
If the experiential features flakes and nix-command are enabled.