### PR TITLE
correct nodejs Render return typedef from `boolean|object` to `false|{...}`

### DIFF
--- a/nodejs/src/DisplayHelp.js
+++ b/nodejs/src/DisplayHelp.js
@@ -26,7 +26,7 @@ const DisplayHelp = () => {
 	const { string: headline } = Render('cfonts', {
 		align: 'left',
 		gradient: ['red', 'green'],
-	}) || { string: '<render failed>'};
+	}) || { string: '<render failed>' };
 
 	console.log(
 		` ${headline}` +

--- a/nodejs/src/DisplayHelp.js
+++ b/nodejs/src/DisplayHelp.js
@@ -26,7 +26,7 @@ const DisplayHelp = () => {
 	const { string: headline } = Render('cfonts', {
 		align: 'left',
 		gradient: ['red', 'green'],
-	}) || { string: '<render failed>' };
+	}) || { string: 'cfonts' };
 
 	console.log(
 		` ${headline}` +

--- a/nodejs/src/DisplayHelp.js
+++ b/nodejs/src/DisplayHelp.js
@@ -26,7 +26,7 @@ const DisplayHelp = () => {
 	const { string: headline } = Render('cfonts', {
 		align: 'left',
 		gradient: ['red', 'green'],
-	});
+	}) || { string: '<render failed>'};
 
 	console.log(
 		` ${headline}` +

--- a/nodejs/src/Render.js
+++ b/nodejs/src/Render.js
@@ -42,13 +42,13 @@ const { Log } = require('./Log.js');
  * @param  {number}  size.width  - The width of the terminal
  * @param  {number}  size.height - The height of the terminal
  *
- * @typedef  {(object|boolean)} ReturnObject
- *   @property {string}  string  - The pure string for output with all line breaks
- *   @property {array}   array   - Each line of output in an array
- *   @property {number}  lines   - The number of lines
- *   @property {object}  options - All options used
+ * @typedef  {object} ReturnObject
+ *   @property {string}        string  - The pure string for output with all line breaks
+ *   @property {Array<string>} array   - Each line of output in an array
+ *   @property {number}        lines   - The number of lines
+ *   @property {object}        options - All options used
  *
- * @return {ReturnObject}        - CLI output of INPUT to be consoled out
+ * @return {ReturnObject|false}        - CLI output of INPUT to be consoled out
  */
 const Render = (input, SETTINGS = {}, debug = DEBUG.enabled, debuglevel = DEBUG.level, size = Size) => {
 	Debugging.report(`Running render`, 1);


### PR DESCRIPTION
Currently Render returns boolean or untyped object.
This seems to be a jsdoc mistype.

See built Render.d.ts diff:
```diff
--- Render.d.ts
+++ Render.d.ts
@@ -1,7 +1,24 @@
 /**
  * Main method to get the ANSI output for a string
  */
-export type ReturnObject = (object | boolean);
+export type ReturnObject = {
+    /**
+     * - The pure string for output with all line breaks
+     */
+    string: string;
+    /**
+     * - Each line of output in an array
+     */
+    array: Array<string>;
+    /**
+     * - The number of lines
+     */
+    lines: number;
+    /**
+     * - All options used
+     */
+    options: object;
+};
 /**
  * Main method to get the ANSI output for a string
  *
@@ -13,15 +30,15 @@
  * @param  {number}  size.width  - The width of the terminal
  * @param  {number}  size.height - The height of the terminal
  *
- * @typedef  {(object|boolean)} ReturnObject
- *   @property {string}  string  - The pure string for output with all line breaks
- *   @property {array}   array   - Each line of output in an array
- *   @property {number}  lines   - The number of lines
- *   @property {object}  options - All options used
+ * @typedef  {object} ReturnObject
+ *   @property {string}        string  - The pure string for output with all line breaks
+ *   @property {Array<string>} array   - Each line of output in an array
+ *   @property {number}        lines   - The number of lines
+ *   @property {object}        options - All options used
  *
- * @return {ReturnObject}        - CLI output of INPUT to be consoled out
+ * @return {ReturnObject|false}        - CLI output of INPUT to be consoled out
  */
 export function Render(input: string, SETTINGS?: object, debug?: boolean, debuglevel?: number, size?: {
     width: number;
     height: number;
-}): ReturnObject;
+}): ReturnObject | false;
```