### PR TITLE
Make the enable-ansi-support dependency Windows-specific

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,12 +17,14 @@ include = ["/fonts", "/src", "!.DS_Store", "/LICENSE"]
 exitcode = "1"
 strum = "0.27"
 strum_macros = "0.27"
-enable-ansi-support = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.9"
 terminal_size = "0.4"
 supports-color = "3"
+
+[target.'cfg(windows)'.dependencies]
+enable-ansi-support = "0.2"
 
 [dev-dependencies]
 temp-env = "0.3"

--- a/rust/src/render.rs
+++ b/rust/src/render.rs
@@ -1,5 +1,5 @@
 //! The contents of this module is all about composing all functions together to render our output
-extern crate enable_ansi_support;
+#[cfg(windows)]
 use enable_ansi_support::enable_ansi_support;
 use terminal_size::{terminal_size, Width};
 
@@ -60,6 +60,7 @@ pub fn render(options: Options) -> RenderedString {
 	d(&format!("render() Options\n{:#?}", options), 1, Dt::Log, &options, &mut std::io::stdout());
 
 	// enable ansi support in windows 10
+	#[cfg(windows)]
 	if let Ok(()) = enable_ansi_support() {
 		d("render() enabled ansi support in windows", 2, Dt::Log, &options, &mut std::io::stdout());
 	}


### PR DESCRIPTION
Avoid unnecessarily compiling `enable-ansi-support` on non-Windows platforms.